### PR TITLE
add airgap artifacts to installation kind

### DIFF
--- a/apis/kots/v1beta1/installation_types.go
+++ b/apis/kots/v1beta1/installation_types.go
@@ -34,6 +34,7 @@ type InstallationSpec struct {
 	ReplicatedChartNames     []string                `json:"replicatedChartNames,omitempty"`
 	EncryptionKey            string                  `json:"encryptionKey,omitempty"`
 	KnownImages              []InstallationImage     `json:"knownImages,omitempty"`
+	AirgapArtifacts          []string                `json:"airgapArtifacts,omitempty"`
 	YAMLErrors               []InstallationYAMLError `json:"yamlErrors,omitempty"`
 }
 

--- a/apis/kots/v1beta1/installation_types.go
+++ b/apis/kots/v1beta1/installation_types.go
@@ -34,7 +34,7 @@ type InstallationSpec struct {
 	ReplicatedChartNames     []string                `json:"replicatedChartNames,omitempty"`
 	EncryptionKey            string                  `json:"encryptionKey,omitempty"`
 	KnownImages              []InstallationImage     `json:"knownImages,omitempty"`
-	AirgapArtifacts          []string                `json:"airgapArtifacts,omitempty"`
+	EmbeddedClusterArtifacts []string                `json:"embeddedClusterArtifacts,omitempty"`
 	YAMLErrors               []InstallationYAMLError `json:"yamlErrors,omitempty"`
 }
 

--- a/apis/kots/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kots/v1beta1/zz_generated.deepcopy.go
@@ -1423,8 +1423,8 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 		*out = make([]InstallationImage, len(*in))
 		copy(*out, *in)
 	}
-	if in.AirgapArtifacts != nil {
-		in, out := &in.AirgapArtifacts, &out.AirgapArtifacts
+	if in.EmbeddedClusterArtifacts != nil {
+		in, out := &in.EmbeddedClusterArtifacts, &out.EmbeddedClusterArtifacts
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/apis/kots/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kots/v1beta1/zz_generated.deepcopy.go
@@ -1423,6 +1423,11 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 		*out = make([]InstallationImage, len(*in))
 		copy(*out, *in)
 	}
+	if in.AirgapArtifacts != nil {
+		in, out := &in.AirgapArtifacts, &out.AirgapArtifacts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.YAMLErrors != nil {
 		in, out := &in.YAMLErrors, &out.YAMLErrors
 		*out = make([]InstallationYAMLError, len(*in))

--- a/config/crds/kots.io_installations.yaml
+++ b/config/crds/kots.io_installations.yaml
@@ -36,6 +36,10 @@ spec:
           spec:
             description: InstallationSpec defines the desired state of InstallationSpec
             properties:
+              airgapArtifacts:
+                items:
+                  type: string
+                type: array
               channelID:
                 type: string
               channelName:

--- a/config/crds/kots.io_installations.yaml
+++ b/config/crds/kots.io_installations.yaml
@@ -36,14 +36,14 @@ spec:
           spec:
             description: InstallationSpec defines the desired state of InstallationSpec
             properties:
-              airgapArtifacts:
-                items:
-                  type: string
-                type: array
               channelID:
                 type: string
               channelName:
                 type: string
+              embeddedClusterArtifacts:
+                items:
+                  type: string
+                type: array
               encryptionKey:
                 type: string
               isRequired:

--- a/schemas/installation-kots-v1beta1.json
+++ b/schemas/installation-kots-v1beta1.json
@@ -17,6 +17,12 @@
       "description": "InstallationSpec defines the desired state of InstallationSpec",
       "type": "object",
       "properties": {
+        "airgapArtifacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "channelID": {
           "type": "string"
         },

--- a/schemas/installation-kots-v1beta1.json
+++ b/schemas/installation-kots-v1beta1.json
@@ -17,17 +17,17 @@
       "description": "InstallationSpec defines the desired state of InstallationSpec",
       "type": "object",
       "properties": {
-        "airgapArtifacts": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "channelID": {
           "type": "string"
         },
         "channelName": {
           "type": "string"
+        },
+        "embeddedClusterArtifacts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "encryptionKey": {
           "type": "string"


### PR DESCRIPTION
Updates the KOTS installation CRD to include an `embeddedClusterArtifacts` field containing a list of OCI artifacts pushed from an airgap bundle. This supports changes in https://github.com/replicatedhq/kots/pull/4524.