### PR TITLE
update embeddedClusterArtifacts type for installation

### DIFF
--- a/apis/kots/v1beta1/airgap_types.go
+++ b/apis/kots/v1beta1/airgap_types.go
@@ -42,7 +42,7 @@ type AirgapReleaseMeta struct {
 	UpdateCursor string `json:"updateCursor,omitempty"`
 }
 
-// EmbeddedClusterArtifacts maps embedded cluster artifacts to their path in the airgap bundle
+// EmbeddedClusterArtifacts maps embedded cluster artifacts to their path
 type EmbeddedClusterArtifacts struct {
 	Charts      string `json:"charts,omitempty"`
 	ImagesAmd64 string `json:"imagesAmd64,omitempty"`

--- a/apis/kots/v1beta1/installation_types.go
+++ b/apis/kots/v1beta1/installation_types.go
@@ -22,20 +22,20 @@ import (
 
 // InstallationSpec defines the desired state of InstallationSpec
 type InstallationSpec struct {
-	UpdateCursor             string                  `json:"updateCursor,omitempty"`
-	ChannelID                string                  `json:"channelID,omitempty"`
-	ChannelName              string                  `json:"channelName,omitempty"`
-	VersionLabel             string                  `json:"versionLabel,omitempty"`
-	IsRequired               bool                    `json:"isRequired,omitempty"`
-	ReleaseNotes             string                  `json:"releaseNotes,omitempty"`
-	ReleasedAt               *metav1.Time            `json:"releasedAt,omitempty"`
-	ReplicatedRegistryDomain string                  `json:"replicatedRegistryDomain,omitempty"`
-	ReplicatedProxyDomain    string                  `json:"replicatedProxyDomain,omitempty"`
-	ReplicatedChartNames     []string                `json:"replicatedChartNames,omitempty"`
-	EncryptionKey            string                  `json:"encryptionKey,omitempty"`
-	KnownImages              []InstallationImage     `json:"knownImages,omitempty"`
-	EmbeddedClusterArtifacts []string                `json:"embeddedClusterArtifacts,omitempty"`
-	YAMLErrors               []InstallationYAMLError `json:"yamlErrors,omitempty"`
+	UpdateCursor             string                    `json:"updateCursor,omitempty"`
+	ChannelID                string                    `json:"channelID,omitempty"`
+	ChannelName              string                    `json:"channelName,omitempty"`
+	VersionLabel             string                    `json:"versionLabel,omitempty"`
+	IsRequired               bool                      `json:"isRequired,omitempty"`
+	ReleaseNotes             string                    `json:"releaseNotes,omitempty"`
+	ReleasedAt               *metav1.Time              `json:"releasedAt,omitempty"`
+	ReplicatedRegistryDomain string                    `json:"replicatedRegistryDomain,omitempty"`
+	ReplicatedProxyDomain    string                    `json:"replicatedProxyDomain,omitempty"`
+	ReplicatedChartNames     []string                  `json:"replicatedChartNames,omitempty"`
+	EncryptionKey            string                    `json:"encryptionKey,omitempty"`
+	KnownImages              []InstallationImage       `json:"knownImages,omitempty"`
+	EmbeddedClusterArtifacts *EmbeddedClusterArtifacts `json:"embeddedClusterArtifacts,omitempty"`
+	YAMLErrors               []InstallationYAMLError   `json:"yamlErrors,omitempty"`
 }
 
 type InstallationImage struct {

--- a/apis/kots/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kots/v1beta1/zz_generated.deepcopy.go
@@ -1445,8 +1445,8 @@ func (in *InstallationSpec) DeepCopyInto(out *InstallationSpec) {
 	}
 	if in.EmbeddedClusterArtifacts != nil {
 		in, out := &in.EmbeddedClusterArtifacts, &out.EmbeddedClusterArtifacts
-		*out = make([]string, len(*in))
-		copy(*out, *in)
+		*out = new(EmbeddedClusterArtifacts)
+		**out = **in
 	}
 	if in.YAMLErrors != nil {
 		in, out := &in.YAMLErrors, &out.YAMLErrors

--- a/config/crds/kots.io_airgaps.yaml
+++ b/config/crds/kots.io_airgaps.yaml
@@ -44,7 +44,7 @@ spec:
                 type: string
               embeddedClusterArtifacts:
                 description: EmbeddedClusterArtifacts maps embedded cluster artifacts
-                  to their path in the airgap bundle
+                  to their path
                 properties:
                   binaryAmd64:
                     type: string

--- a/config/crds/kots.io_installations.yaml
+++ b/config/crds/kots.io_installations.yaml
@@ -44,11 +44,11 @@ spec:
                 description: EmbeddedClusterArtifacts maps embedded cluster artifacts
                   to their path
                 properties:
-                  binary:
+                  binaryAmd64:
                     type: string
                   charts:
                     type: string
-                  images:
+                  imagesAmd64:
                     type: string
                   metadata:
                     type: string

--- a/config/crds/kots.io_installations.yaml
+++ b/config/crds/kots.io_installations.yaml
@@ -41,9 +41,18 @@ spec:
               channelName:
                 type: string
               embeddedClusterArtifacts:
-                items:
-                  type: string
-                type: array
+                description: EmbeddedClusterArtifacts maps embedded cluster artifacts
+                  to their path
+                properties:
+                  binary:
+                    type: string
+                  charts:
+                    type: string
+                  images:
+                    type: string
+                  metadata:
+                    type: string
+                type: object
               encryptionKey:
                 type: string
               isRequired:

--- a/schemas/airgap-kots-v1beta1.json
+++ b/schemas/airgap-kots-v1beta1.json
@@ -27,7 +27,7 @@
           "type": "string"
         },
         "embeddedClusterArtifacts": {
-          "description": "EmbeddedClusterArtifacts maps embedded cluster artifacts to their path in the airgap bundle",
+          "description": "EmbeddedClusterArtifacts maps embedded cluster artifacts to their path",
           "type": "object",
           "properties": {
             "binaryAmd64": {

--- a/schemas/installation-kots-v1beta1.json
+++ b/schemas/installation-kots-v1beta1.json
@@ -27,13 +27,13 @@
           "description": "EmbeddedClusterArtifacts maps embedded cluster artifacts to their path",
           "type": "object",
           "properties": {
-            "binary": {
+            "binaryAmd64": {
               "type": "string"
             },
             "charts": {
               "type": "string"
             },
-            "images": {
+            "imagesAmd64": {
               "type": "string"
             },
             "metadata": {

--- a/schemas/installation-kots-v1beta1.json
+++ b/schemas/installation-kots-v1beta1.json
@@ -24,9 +24,21 @@
           "type": "string"
         },
         "embeddedClusterArtifacts": {
-          "type": "array",
-          "items": {
-            "type": "string"
+          "description": "EmbeddedClusterArtifacts maps embedded cluster artifacts to their path",
+          "type": "object",
+          "properties": {
+            "binary": {
+              "type": "string"
+            },
+            "charts": {
+              "type": "string"
+            },
+            "images": {
+              "type": "string"
+            },
+            "metadata": {
+              "type": "string"
+            }
           }
         },
         "encryptionKey": {


### PR DESCRIPTION
Updates the `embeddedClusterArtifacts` field in the Installation schema to be a direct mapping of artifact type to path. In this case, the path will the the OCI artifact path. This allows KOTS to persist these artifact locations between bundle upload and application deployment. These OCI paths will be used when creating the Installation resource for Embedded Cluster upgrades.