### PR TITLE
specific amd64 embedded artifact field names

### DIFF
--- a/apis/kots/v1beta1/airgap_types.go
+++ b/apis/kots/v1beta1/airgap_types.go
@@ -44,10 +44,10 @@ type AirgapReleaseMeta struct {
 
 // EmbeddedClusterArtifacts maps embedded cluster artifacts to their path in the airgap bundle
 type EmbeddedClusterArtifacts struct {
-	Charts   string `json:"charts,omitempty"`
-	Images   string `json:"images,omitempty"`
-	Binary   string `json:"binary,omitempty"`
-	Metadata string `json:"metadata,omitempty"`
+	Charts      string `json:"charts,omitempty"`
+	ImagesAmd64 string `json:"imagesAmd64,omitempty"`
+	BinaryAmd64 string `json:"binaryAmd64,omitempty"`
+	Metadata    string `json:"metadata,omitempty"`
 }
 
 // AirgapStatus defines the observed state of Airgap

--- a/config/crds/kots.io_airgaps.yaml
+++ b/config/crds/kots.io_airgaps.yaml
@@ -46,11 +46,11 @@ spec:
                 description: EmbeddedClusterArtifacts maps embedded cluster artifacts
                   to their path in the airgap bundle
                 properties:
-                  binary:
+                  binaryAmd64:
                     type: string
                   charts:
                     type: string
-                  images:
+                  imagesAmd64:
                     type: string
                   metadata:
                     type: string

--- a/schemas/airgap-kots-v1beta1.json
+++ b/schemas/airgap-kots-v1beta1.json
@@ -30,13 +30,13 @@
           "description": "EmbeddedClusterArtifacts maps embedded cluster artifacts to their path in the airgap bundle",
           "type": "object",
           "properties": {
-            "binary": {
+            "binaryAmd64": {
               "type": "string"
             },
             "charts": {
               "type": "string"
             },
-            "images": {
+            "imagesAmd64": {
               "type": "string"
             },
             "metadata": {


### PR DESCRIPTION
updates the field names for the images and binary in the `embeddedClusterArtifacts` field to be specific to the amd64 architecture. this allows for flexibility when adding support for other architectures later on.