### PR TITLE
feat: implement sum of embedded cluster artifacts

### DIFF
--- a/apis/kots/v1beta1/airgap_types.go
+++ b/apis/kots/v1beta1/airgap_types.go
@@ -52,6 +52,31 @@ type EmbeddedClusterArtifacts struct {
 	AdditionalArtifacts map[string]string       `json:"additionalArtifacts,omitempty"`
 }
 
+// Total returns the total amount of embedded cluster artifacts contained in
+// the airgap bundle. Sums up the amount of charts, images, binaries, metadata
+// and additional artifacts.
+func (e *EmbeddedClusterArtifacts) Total() int {
+	total := 0
+	if e == nil {
+		return total
+	}
+	if e.Charts != "" {
+		total++
+	}
+	if e.ImagesAmd64 != "" {
+		total++
+	}
+	if e.BinaryAmd64 != "" {
+		total++
+	}
+	if e.Metadata != "" {
+		total++
+	}
+	total += len(e.AdditionalArtifacts)
+	total += len(e.Registry.SavedImages)
+	return total
+}
+
 // EmbeddedClusterRegistry holds a directory from where a images can be read and later
 // pushed to the embedded cluster registry. Format inside the directory is the same as
 // the registry storage format.

--- a/apis/kots/v1beta1/v1beta1tests/airgap_types_test.go
+++ b/apis/kots/v1beta1/v1beta1tests/airgap_types_test.go
@@ -1,0 +1,88 @@
+package v1beta1tests
+
+import (
+	"testing"
+
+	"github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedClusterArtifactsTotal(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		airgap *v1beta1.Airgap
+		want   int
+	}{
+		{
+			name:   "undefined embedded cluster artifacts",
+			airgap: &v1beta1.Airgap{},
+			want:   0,
+		},
+		{
+			name: "no images and not additional",
+			airgap: &v1beta1.Airgap{
+				Spec: v1beta1.AirgapSpec{
+					EmbeddedClusterArtifacts: &v1beta1.EmbeddedClusterArtifacts{
+						Charts:      "charts",
+						ImagesAmd64: "images",
+						BinaryAmd64: "binary",
+						Metadata:    "metadata",
+					},
+				},
+			},
+			want: 4,
+		},
+		{
+			name: "only additional artifacts",
+			airgap: &v1beta1.Airgap{
+				Spec: v1beta1.AirgapSpec{
+					EmbeddedClusterArtifacts: &v1beta1.EmbeddedClusterArtifacts{
+						AdditionalArtifacts: map[string]string{
+							"foo": "bar",
+							"baz": "qux",
+						},
+					},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "only embedded cluster images",
+			airgap: &v1beta1.Airgap{
+				Spec: v1beta1.AirgapSpec{
+					EmbeddedClusterArtifacts: &v1beta1.EmbeddedClusterArtifacts{
+						Registry: v1beta1.EmbeddedClusterRegistry{
+							SavedImages: []string{"foo", "bar", "baz"},
+						},
+					},
+				},
+			},
+			want: 3,
+		},
+		{
+			name: "various embedded cluster artifacts",
+			airgap: &v1beta1.Airgap{
+				Spec: v1beta1.AirgapSpec{
+					EmbeddedClusterArtifacts: &v1beta1.EmbeddedClusterArtifacts{
+						Charts:      "charts",
+						ImagesAmd64: "images",
+						BinaryAmd64: "binary",
+						Metadata:    "metadata",
+						AdditionalArtifacts: map[string]string{
+							"foo": "bar",
+							"baz": "qux",
+						},
+						Registry: v1beta1.EmbeddedClusterRegistry{
+							SavedImages: []string{"foo", "bar", "baz"},
+						},
+					},
+				},
+			},
+			want: 9,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.airgap.Spec.EmbeddedClusterArtifacts.Total(), tt.want)
+		})
+	}
+}


### PR DESCRIPTION
makes a function to count all embedded cluster present in an airgap definition. this function will be used later on when giving user feedback about the amount of artifacts we need to push.

as we are pushing different kinds of artifacts in different parts of the kots source code it makes sense to implement this as part of the embedded cluster artifacts struct.