### PR TITLE
add excluded images array to kots application spec

### DIFF
--- a/apis/kots/v1beta1/application_types.go
+++ b/apis/kots/v1beta1/application_types.go
@@ -55,6 +55,7 @@ type ApplicationSpec struct {
 	MinKotsVersion               string              `json:"minKotsVersion,omitempty"`
 	TargetKotsVersion            string              `json:"targetKotsVersion,omitempty"`
 	AdditionalImages             []string            `json:"additionalImages,omitempty"`
+	ExcludedImages               []string            `json:"excludedImages,omitempty"`
 	AdditionalNamespaces         []string            `json:"additionalNamespaces,omitempty"`
 	RequireMinimalRBACPrivileges bool                `json:"requireMinimalRBACPrivileges,omitempty"`
 	SupportMinimalRBACPrivileges bool                `json:"supportMinimalRBACPrivileges,omitempty"`


### PR DESCRIPTION
https://app.shortcut.com/replicated/story/119848/allow-excluding-images-from-airgap-builds

Apparently some charts have placeholder images in the spec that can't be changed with helm values, and so we need to exclude them from the airgap build to keep it from failing