### PR TITLE
feat: add IsEmbeddedClusterRookEnabled to license spec

### DIFF
--- a/apis/kots/v1beta1/license_types.go
+++ b/apis/kots/v1beta1/license_types.go
@@ -210,6 +210,7 @@ type LicenseSpec struct {
 	IsSemverRequired                  bool                        `json:"isSemverRequired,omitempty"`
 	IsEmbeddedClusterDownloadEnabled  bool                        `json:"isEmbeddedClusterDownloadEnabled,omitempty"`
 	IsEmbeddedClusterMultiNodeEnabled bool                        `json:"isEmbeddedClusterMultiNodeEnabled,omitempty"`
+	IsEmbeddedClusterRookEnabled      bool                        `json:"isEmbeddedClusterRookEnabled,omitempty"`
 	Entitlements                      map[string]EntitlementField `json:"entitlements,omitempty"`
 }
 
@@ -481,6 +482,13 @@ func (l *License) compareLicenseData(signedJSON []byte) error {
 			FieldName:   "isEmbeddedClusterMultiNodeEnabled",
 			SignedValue: fmt.Sprintf("%t", signedData.Spec.IsEmbeddedClusterMultiNodeEnabled),
 			ActualValue: fmt.Sprintf("%t", outerData.IsEmbeddedClusterMultiNodeEnabled),
+		}
+	}
+	if outerData.IsEmbeddedClusterRookEnabled != signedData.Spec.IsEmbeddedClusterRookEnabled {
+		return &types.LicenseDataValidationError{
+			FieldName:   "isEmbeddedClusterRookEnabled",
+			SignedValue: fmt.Sprintf("%t", signedData.Spec.IsEmbeddedClusterRookEnabled),
+			ActualValue: fmt.Sprintf("%t", outerData.IsEmbeddedClusterRookEnabled),
 		}
 	}
 

--- a/apis/kots/v1beta2/license_types.go
+++ b/apis/kots/v1beta2/license_types.go
@@ -137,6 +137,7 @@ type LicenseSpec struct {
 	IsSemverRequired                  bool                        `json:"isSemverRequired,omitempty"`
 	IsEmbeddedClusterDownloadEnabled  bool                        `json:"isEmbeddedClusterDownloadEnabled,omitempty"`
 	IsEmbeddedClusterMultiNodeEnabled bool                        `json:"isEmbeddedClusterMultiNodeEnabled,omitempty"`
+	IsEmbeddedClusterRookEnabled      bool                        `json:"isEmbeddedClusterRookEnabled,omitempty"`
 	Entitlements                      map[string]EntitlementField `json:"entitlements,omitempty"`
 }
 
@@ -407,6 +408,13 @@ func (l *License) compareLicenseData(signedJSON []byte) error {
 			FieldName:   "isEmbeddedClusterMultiNodeEnabled",
 			SignedValue: fmt.Sprintf("%t", signedData.Spec.IsEmbeddedClusterMultiNodeEnabled),
 			ActualValue: fmt.Sprintf("%t", outerData.IsEmbeddedClusterMultiNodeEnabled),
+		}
+	}
+	if outerData.IsEmbeddedClusterRookEnabled != signedData.Spec.IsEmbeddedClusterRookEnabled {
+		return &types.LicenseDataValidationError{
+			FieldName:   "isEmbeddedClusterRookEnabled",
+			SignedValue: fmt.Sprintf("%t", signedData.Spec.IsEmbeddedClusterRookEnabled),
+			ActualValue: fmt.Sprintf("%t", outerData.IsEmbeddedClusterRookEnabled),
 		}
 	}
 

--- a/config/crds/kots.io_licenses.yaml
+++ b/config/crds/kots.io_licenses.yaml
@@ -108,6 +108,8 @@ spec:
                 type: boolean
               isEmbeddedClusterMultiNodeEnabled:
                 type: boolean
+              isEmbeddedClusterRookEnabled:
+                type: boolean
               isGeoaxisSupported:
                 type: boolean
               isGitOpsSupported:
@@ -236,6 +238,8 @@ spec:
               isEmbeddedClusterDownloadEnabled:
                 type: boolean
               isEmbeddedClusterMultiNodeEnabled:
+                type: boolean
+              isEmbeddedClusterRookEnabled:
                 type: boolean
               isGeoaxisSupported:
                 type: boolean

--- a/pkg/licensewrapper/licensewrapper.go
+++ b/pkg/licensewrapper/licensewrapper.go
@@ -302,6 +302,17 @@ func (w LicenseWrapper) IsEmbeddedClusterMultiNodeEnabled() bool {
 	return false
 }
 
+// IsEmbeddedClusterRookEnabled returns whether embedded cluster rook is enabled from whichever version is present
+func (w LicenseWrapper) IsEmbeddedClusterRookEnabled() bool {
+	if w.V1 != nil {
+		return w.V1.Spec.IsEmbeddedClusterRookEnabled
+	}
+	if w.V2 != nil {
+		return w.V2.Spec.IsEmbeddedClusterRookEnabled
+	}
+	return false
+}
+
 // GetEntitlements returns the entitlements map from whichever version is present
 // Returns wrapped entitlements for version-agnostic access
 func (w LicenseWrapper) GetEntitlements() map[string]EntitlementFieldWrapper {

--- a/schemas/license-kots-v1beta1.json
+++ b/schemas/license-kots-v1beta1.json
@@ -121,6 +121,9 @@
         "isEmbeddedClusterMultiNodeEnabled": {
           "type": "boolean"
         },
+        "isEmbeddedClusterRookEnabled": {
+          "type": "boolean"
+        },
         "isGeoaxisSupported": {
           "type": "boolean"
         },

--- a/schemas/license-kots-v1beta2.json
+++ b/schemas/license-kots-v1beta2.json
@@ -119,6 +119,9 @@
         "isEmbeddedClusterMultiNodeEnabled": {
           "type": "boolean"
         },
+        "isEmbeddedClusterRookEnabled": {
+          "type": "boolean"
+        },
         "isGeoaxisSupported": {
           "type": "boolean"
         },


### PR DESCRIPTION
## Summary
- Add `IsEmbeddedClusterRookEnabled` field to v1beta1 and v1beta2 `LicenseSpec`
- Add signature validation for the new field in `compareLicenseData`
- Add `IsEmbeddedClusterRookEnabled()` accessor to `LicenseWrapper`
- Regenerated schemas, CRDs, and deepcopy via `make all`

## Context
This supports a new replicated entitlement (`enable_embedded_cluster_rook`) in vandoor that controls whether embedded cluster rook is enabled per-vendor. The field is derived from the vendor's team-level entitlement and included in the license spec.

## Test plan
- [x] `go test ./...` passes
- [x] `make all` regenerates schemas/CRDs cleanly
- [ ] Verify vandoor integration tests pass after updating `go.mod` to reference this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)