### PR TITLE
feat(helmchart): tolerate string-or-map optionalValues[].values (sc-138613)

### DIFF
--- a/apis/kots/v1beta1/helmchart_types.go
+++ b/apis/kots/v1beta1/helmchart_types.go
@@ -397,9 +397,14 @@ type OptionalValue struct {
 	Values map[string]MappedChartValue `json:"values,omitempty"`
 
 	// valuesString holds the raw scalar form of values when it is provided as a string, e.g. a
-	// `repl{{ ConfigOption "x" | nindent 8 }}` template that renders to a map at install time. The
-	// Vendor Portal validates specs before template rendering, so it must tolerate this form
-	// instead of dropping the whole HelmChart CR. Exactly one of Values / valuesString is ever set.
+	// `repl{{ ConfigOption "x" | nindent 8 }}` template. The scalar is stored VERBATIM: this type
+	// never parses or template-evaluates it (its contents are not interpreted as JSON or YAML). It
+	// exists only so the pre-render validation path (Vendor Portal) tolerates the scalar instead of
+	// dropping the whole HelmChart CR; it is read back only by ValuesString() and re-emitted verbatim
+	// by MarshalJSON. The actual render-then-reparse happens in KOTS at install, at the manifest-text
+	// level: `repl{{ ... | nindent N }}` renders into indented YAML in the document, so KOTS's normal
+	// decode sees a real map node and populates Values (the map branch), never this string branch.
+	// Exactly one of Values / valuesString is ever set.
 	valuesString string `json:"-"`
 }
 

--- a/apis/kots/v1beta1/helmchart_types.go
+++ b/apis/kots/v1beta1/helmchart_types.go
@@ -444,7 +444,17 @@ func (o *OptionalValue) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.Errorf("optionalValues[].values must be a map or a string, got %q", trimmed)
+	return errors.Errorf("optionalValues[].values must be a map or a string, got %q", truncateForError(trimmed))
+}
+
+// truncateForError bounds an untrusted value before it lands in an error message, so a huge invalid
+// payload can't bloat logs. %q escaping still applies at the call site.
+func truncateForError(s string) string {
+	const max = 64
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
 }
 
 // MarshalJSON re-emits values in whichever form it was decoded from, so a round-trip is lossless.

--- a/apis/kots/v1beta1/helmchart_types.go
+++ b/apis/kots/v1beta1/helmchart_types.go
@@ -392,7 +392,90 @@ type OptionalValue struct {
 	When           string `json:"when"`
 	RecursiveMerge bool   `json:"recursiveMerge"`
 
+	// Values holds the map form of the optional values. This is the form KOTS decodes at install
+	// time, because templates are rendered before the manifest is unmarshalled.
 	Values map[string]MappedChartValue `json:"values,omitempty"`
+
+	// valuesString holds the raw scalar form of values when it is provided as a string, e.g. a
+	// `repl{{ ConfigOption "x" | nindent 8 }}` template that renders to a map at install time. The
+	// Vendor Portal validates specs before template rendering, so it must tolerate this form
+	// instead of dropping the whole HelmChart CR. Exactly one of Values / valuesString is ever set.
+	valuesString string `json:"-"`
+}
+
+// optionalValueJSON mirrors OptionalValue's serialized shape but with values left as a raw message
+// so UnmarshalJSON can decode either a map or a scalar string without recursing into OptionalValue.
+type optionalValueJSON struct {
+	When           string          `json:"when"`
+	RecursiveMerge bool            `json:"recursiveMerge"`
+	Values         json.RawMessage `json:"values,omitempty"`
+}
+
+// UnmarshalJSON tolerates spec.optionalValues[].values being either a map (the rendered form) or a
+// scalar string (a repl template the Vendor Portal sees before rendering). A scalar is stored as a
+// string and leaves Values nil (type-indeterminate) so the CR still decodes and is not dropped.
+func (o *OptionalValue) UnmarshalJSON(data []byte) error {
+	var raw optionalValueJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	o.When = raw.When
+	o.RecursiveMerge = raw.RecursiveMerge
+	o.Values = nil
+	o.valuesString = ""
+
+	trimmed := strings.TrimSpace(string(raw.Values))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+
+	// Prefer the map form. Fall back to a scalar string (e.g. a repl template) rather than failing
+	// the decode and dropping the chart.
+	var values map[string]MappedChartValue
+	if err := json.Unmarshal(raw.Values, &values); err == nil {
+		o.Values = values
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(raw.Values, &str); err == nil {
+		o.valuesString = str
+		return nil
+	}
+
+	return errors.Errorf("optionalValues[].values must be a map or a string, got %q", trimmed)
+}
+
+// MarshalJSON re-emits values in whichever form it was decoded from, so a round-trip is lossless.
+func (o OptionalValue) MarshalJSON() ([]byte, error) {
+	raw := optionalValueJSON{
+		When:           o.When,
+		RecursiveMerge: o.RecursiveMerge,
+	}
+
+	switch {
+	case o.valuesString != "":
+		encoded, err := json.Marshal(o.valuesString)
+		if err != nil {
+			return nil, err
+		}
+		raw.Values = encoded
+	case o.Values != nil:
+		encoded, err := json.Marshal(o.Values)
+		if err != nil {
+			return nil, err
+		}
+		raw.Values = encoded
+	}
+
+	return json.Marshal(raw)
+}
+
+// ValuesString returns the raw scalar form of optionalValues[].values (a repl template) when values
+// was provided as a string rather than a map; it returns "" for the map form.
+func (o *OptionalValue) ValuesString() string {
+	return o.valuesString
 }
 
 // HelmChartSpec defines the desired state of HelmChartSpec

--- a/apis/kots/v1beta1/optionalvalue_stringormap_test.go
+++ b/apis/kots/v1beta1/optionalvalue_stringormap_test.go
@@ -1,0 +1,85 @@
+package v1beta1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_OptionalValue_ValuesStringOrMap verifies that spec.optionalValues[].values decodes from
+// BOTH a YAML mapping (the form KOTS sees after template rendering) and a scalar string (a
+// `repl{{ ... }}` template the Vendor Portal sees before rendering). The scalar form must NOT
+// error, otherwise the whole HelmChart CR is dropped and the release is falsely flagged "not
+// installable with KOTS". See sc-138613 / itrs-replicated#380.
+func Test_OptionalValue_ValuesStringOrMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantString bool
+	}{
+		{
+			name:       "map form",
+			input:      `{"when":"true","recursiveMerge":true,"values":{"operator":{"enabled":true}}}`,
+			wantString: false,
+		},
+		{
+			name:       "templated repl{{ }} scalar is tolerated",
+			input:      `{"when":"true","recursiveMerge":false,"values":"repl{{ ConfigOption \"override\" | nindent 8 }}"}`,
+			wantString: true,
+		},
+		{
+			name:       "{{repl }} alt-delimiter scalar is tolerated",
+			input:      `{"when":"true","values":"{{repl ConfigOption \"override\" | nindent 8 }}"}`,
+			wantString: true,
+		},
+		{
+			name:       "non-templated scalar is tolerated, not an error",
+			input:      `{"when":"true","values":"this is not a map"}`,
+			wantString: true,
+		},
+		{
+			name:       "omitted values",
+			input:      `{"when":"false"}`,
+			wantString: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ov OptionalValue
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &ov))
+
+			if tt.wantString {
+				assert.Nil(t, ov.Values, "a scalar values must leave the typed map empty (type-indeterminate)")
+				assert.NotEmpty(t, ov.valuesString, "a scalar values must be preserved as a string")
+			} else {
+				assert.Empty(t, ov.valuesString)
+			}
+
+			// A marshal/unmarshal round-trip must be idempotent: a string stays a string, a map
+			// stays a map.
+			out, err := json.Marshal(ov)
+			require.NoError(t, err)
+
+			var rt OptionalValue
+			require.NoError(t, json.Unmarshal(out, &rt))
+			assert.Equal(t, ov, rt, "OptionalValue must survive a marshal/unmarshal round-trip")
+		})
+	}
+}
+
+// Test_HelmChartSpec_ToleratesTemplatedScalarOptionalValues proves the bug fix at the spec level:
+// a HelmChartSpec whose optionalValues[].values is a templated scalar must decode without error so
+// the CR is not dropped from the installability check.
+func Test_HelmChartSpec_ToleratesTemplatedScalarOptionalValues(t *testing.T) {
+	spec := `{"chart":{"name":"issue380","chartVersion":"1.0.0"},"optionalValues":[{"when":"true","recursiveMerge":true,"values":"repl{{ ConfigOption \"override\" | nindent 8 }}"}]}`
+
+	var s HelmChartSpec
+	require.NoError(t, json.Unmarshal([]byte(spec), &s))
+
+	assert.Equal(t, "issue380", s.Chart.Name)
+	require.Len(t, s.OptionalValues, 1)
+	assert.Nil(t, s.OptionalValues[0].Values, "templated scalar leaves the typed map empty")
+}

--- a/apis/kots/v1beta1/optionalvalue_stringormap_test.go
+++ b/apis/kots/v1beta1/optionalvalue_stringormap_test.go
@@ -83,3 +83,26 @@ func Test_HelmChartSpec_ToleratesTemplatedScalarOptionalValues(t *testing.T) {
 	require.Len(t, s.OptionalValues, 1)
 	assert.Nil(t, s.OptionalValues[0].Values, "templated scalar leaves the typed map empty")
 }
+
+// Test_OptionalValue_DeepCopyPreservesValuesString locks the invariant that a scalar values
+// survives DeepCopy/DeepCopyInto. Correctness holds today only because valuesString is a value-type
+// string copied by the generated `*out = *in`; this test fails loudly if that ever stops being true
+// (e.g. the field becomes a pointer/slice and the generated deepcopy stops covering it).
+func Test_OptionalValue_DeepCopyPreservesValuesString(t *testing.T) {
+	var ov OptionalValue
+	require.NoError(t, json.Unmarshal([]byte(`{"when":"true","values":"repl{{ ConfigOption \"override\" | nindent 8 }}"}`), &ov))
+	require.NotEmpty(t, ov.ValuesString())
+
+	cp := ov.DeepCopy()
+	assert.Equal(t, ov.ValuesString(), cp.ValuesString(), "scalar must survive DeepCopy")
+
+	var into OptionalValue
+	ov.DeepCopyInto(&into)
+	assert.Equal(t, ov.ValuesString(), into.ValuesString(), "scalar must survive DeepCopyInto")
+
+	orig, err := json.Marshal(ov)
+	require.NoError(t, err)
+	copied, err := json.Marshal(cp)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(orig), string(copied), "a deep copy must re-marshal identically")
+}

--- a/apis/kots/v1beta1/optionalvalue_yaml_test.go
+++ b/apis/kots/v1beta1/optionalvalue_yaml_test.go
@@ -1,0 +1,120 @@
+package v1beta1_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1beta1 "github.com/replicatedhq/kotskinds/apis/kots/v1beta1"
+	kotsscheme "github.com/replicatedhq/kotskinds/client/kotsclientset/scheme"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// Test_OptionalValue_YAMLDecode_StringOrMap proves the string-or-map tolerance on
+// optionalValues[].values works for YAML input, not just JSON — and that YAML and JSON decode to
+// the same thing.
+//
+// There is deliberately NO UnmarshalYAML on OptionalValue. Every real decode path converts YAML to
+// JSON and then calls json.Unmarshal: sigs.k8s.io/yaml does it directly, and the k8s
+// UniversalDeserializer (the path kots and vandoor actually use) routes YAML through its JSON/YAML
+// serializer. So the custom UnmarshalJSON fires either way. This matches the repo's existing
+// dual-type convention (multitype.BoolOrString, MappedChartValue implement JSON hooks only). Adding
+// UnmarshalYAML would be redundant. See sc-138613 / itrs-replicated#380.
+//
+// This is an external test package (v1beta1_test) on purpose: it decodes via
+// client/kotsclientset/scheme, which imports this API package, so an in-package test would be an
+// import cycle. It only needs the exported ValuesString()/Values, so external is fine.
+func Test_OptionalValue_YAMLDecode_StringOrMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		yamlDoc    string
+		jsonDoc    string
+		wantString bool
+	}{
+		{
+			name: "templated repl{{ }} scalar",
+			yamlDoc: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: issue380
+spec:
+  chart:
+    name: issue380
+    chartVersion: 1.0.0
+  optionalValues:
+    - when: "true"
+      values: 'repl{{ ConfigOption "override" | nindent 8 }}'`,
+			jsonDoc:    `{"apiVersion":"kots.io/v1beta1","kind":"HelmChart","metadata":{"name":"issue380"},"spec":{"chart":{"name":"issue380","chartVersion":"1.0.0"},"optionalValues":[{"when":"true","values":"repl{{ ConfigOption \"override\" | nindent 8 }}"}]}}`,
+			wantString: true,
+		},
+		{
+			name: "{{repl }} alt-delimiter scalar",
+			yamlDoc: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: issue380
+spec:
+  chart:
+    name: issue380
+    chartVersion: 1.0.0
+  optionalValues:
+    - when: "true"
+      values: '{{repl ConfigOption "override" | nindent 8 }}'`,
+			jsonDoc:    `{"apiVersion":"kots.io/v1beta1","kind":"HelmChart","metadata":{"name":"issue380"},"spec":{"chart":{"name":"issue380","chartVersion":"1.0.0"},"optionalValues":[{"when":"true","values":"{{repl ConfigOption \"override\" | nindent 8 }}"}]}}`,
+			wantString: true,
+		},
+		{
+			name: "map values",
+			yamlDoc: `apiVersion: kots.io/v1beta1
+kind: HelmChart
+metadata:
+  name: issue380
+spec:
+  chart:
+    name: issue380
+    chartVersion: 1.0.0
+  optionalValues:
+    - when: "true"
+      values:
+        operator:
+          enabled: true`,
+			jsonDoc:    `{"apiVersion":"kots.io/v1beta1","kind":"HelmChart","metadata":{"name":"issue380"},"spec":{"chart":{"name":"issue380","chartVersion":"1.0.0"},"optionalValues":[{"when":"true","values":{"operator":{"enabled":true}}}]}}`,
+			wantString: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 1. sigs.k8s.io/yaml: YAML -> JSON -> json.Unmarshal (fires UnmarshalJSON).
+			var viaYAML v1beta1.HelmChart
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yamlDoc), &viaYAML))
+
+			// 2. The k8s UniversalDeserializer — how kots/vandoor actually decode manifests.
+			obj, _, err := kotsscheme.Codecs.UniversalDeserializer().Decode([]byte(tt.yamlDoc), nil, nil)
+			require.NoError(t, err)
+			viaScheme, ok := obj.(*v1beta1.HelmChart)
+			require.True(t, ok, "decoded object must be a *v1beta1.HelmChart")
+
+			// 3. Direct JSON decode, for the equivalence assertion.
+			var viaJSON v1beta1.HelmChart
+			require.NoError(t, json.Unmarshal([]byte(tt.jsonDoc), &viaJSON))
+
+			for _, hc := range []*v1beta1.HelmChart{&viaYAML, viaScheme, &viaJSON} {
+				require.Len(t, hc.Spec.OptionalValues, 1)
+				ov := hc.Spec.OptionalValues[0]
+				if tt.wantString {
+					assert.Nil(t, ov.Values, "a scalar values must leave the typed map empty")
+					assert.NotEmpty(t, ov.ValuesString(), "a scalar values must be preserved as a string")
+				} else {
+					assert.NotNil(t, ov.Values, "a map values must populate the typed map")
+					assert.Empty(t, ov.ValuesString())
+				}
+			}
+
+			// YAML (both routes) must decode equivalently to JSON.
+			assert.Equal(t, viaJSON.Spec.OptionalValues, viaYAML.Spec.OptionalValues, "sigs.k8s.io/yaml decode must match JSON decode")
+			assert.Equal(t, viaJSON.Spec.OptionalValues, viaScheme.Spec.OptionalValues, "UniversalDeserializer decode must match JSON decode")
+		})
+	}
+}

--- a/apis/kots/v1beta2/helmchart_types.go
+++ b/apis/kots/v1beta2/helmchart_types.go
@@ -393,9 +393,14 @@ type OptionalValue struct {
 	Values map[string]MappedChartValue `json:"values,omitempty"`
 
 	// valuesString holds the raw scalar form of values when it is provided as a string, e.g. a
-	// `repl{{ ConfigOption "x" | nindent 8 }}` template that renders to a map at install time. The
-	// Vendor Portal validates specs before template rendering, so it must tolerate this form
-	// instead of dropping the whole HelmChart CR. Exactly one of Values / valuesString is ever set.
+	// `repl{{ ConfigOption "x" | nindent 8 }}` template. The scalar is stored VERBATIM: this type
+	// never parses or template-evaluates it (its contents are not interpreted as JSON or YAML). It
+	// exists only so the pre-render validation path (Vendor Portal) tolerates the scalar instead of
+	// dropping the whole HelmChart CR; it is read back only by ValuesString() and re-emitted verbatim
+	// by MarshalJSON. The actual render-then-reparse happens in KOTS at install, at the manifest-text
+	// level: `repl{{ ... | nindent N }}` renders into indented YAML in the document, so KOTS's normal
+	// decode sees a real map node and populates Values (the map branch), never this string branch.
+	// Exactly one of Values / valuesString is ever set.
 	valuesString string `json:"-"`
 }
 

--- a/apis/kots/v1beta2/helmchart_types.go
+++ b/apis/kots/v1beta2/helmchart_types.go
@@ -440,7 +440,17 @@ func (o *OptionalValue) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.Errorf("optionalValues[].values must be a map or a string, got %q", trimmed)
+	return errors.Errorf("optionalValues[].values must be a map or a string, got %q", truncateForError(trimmed))
+}
+
+// truncateForError bounds an untrusted value before it lands in an error message, so a huge invalid
+// payload can't bloat logs. %q escaping still applies at the call site.
+func truncateForError(s string) string {
+	const max = 64
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
 }
 
 // MarshalJSON re-emits values in whichever form it was decoded from, so a round-trip is lossless.

--- a/apis/kots/v1beta2/helmchart_types.go
+++ b/apis/kots/v1beta2/helmchart_types.go
@@ -388,7 +388,90 @@ type OptionalValue struct {
 	When           string `json:"when"`
 	RecursiveMerge bool   `json:"recursiveMerge"`
 
+	// Values holds the map form of the optional values. This is the form KOTS decodes at install
+	// time, because templates are rendered before the manifest is unmarshalled.
 	Values map[string]MappedChartValue `json:"values,omitempty"`
+
+	// valuesString holds the raw scalar form of values when it is provided as a string, e.g. a
+	// `repl{{ ConfigOption "x" | nindent 8 }}` template that renders to a map at install time. The
+	// Vendor Portal validates specs before template rendering, so it must tolerate this form
+	// instead of dropping the whole HelmChart CR. Exactly one of Values / valuesString is ever set.
+	valuesString string `json:"-"`
+}
+
+// optionalValueJSON mirrors OptionalValue's serialized shape but with values left as a raw message
+// so UnmarshalJSON can decode either a map or a scalar string without recursing into OptionalValue.
+type optionalValueJSON struct {
+	When           string          `json:"when"`
+	RecursiveMerge bool            `json:"recursiveMerge"`
+	Values         json.RawMessage `json:"values,omitempty"`
+}
+
+// UnmarshalJSON tolerates spec.optionalValues[].values being either a map (the rendered form) or a
+// scalar string (a repl template the Vendor Portal sees before rendering). A scalar is stored as a
+// string and leaves Values nil (type-indeterminate) so the CR still decodes and is not dropped.
+func (o *OptionalValue) UnmarshalJSON(data []byte) error {
+	var raw optionalValueJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	o.When = raw.When
+	o.RecursiveMerge = raw.RecursiveMerge
+	o.Values = nil
+	o.valuesString = ""
+
+	trimmed := strings.TrimSpace(string(raw.Values))
+	if trimmed == "" || trimmed == "null" {
+		return nil
+	}
+
+	// Prefer the map form. Fall back to a scalar string (e.g. a repl template) rather than failing
+	// the decode and dropping the chart.
+	var values map[string]MappedChartValue
+	if err := json.Unmarshal(raw.Values, &values); err == nil {
+		o.Values = values
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(raw.Values, &str); err == nil {
+		o.valuesString = str
+		return nil
+	}
+
+	return errors.Errorf("optionalValues[].values must be a map or a string, got %q", trimmed)
+}
+
+// MarshalJSON re-emits values in whichever form it was decoded from, so a round-trip is lossless.
+func (o OptionalValue) MarshalJSON() ([]byte, error) {
+	raw := optionalValueJSON{
+		When:           o.When,
+		RecursiveMerge: o.RecursiveMerge,
+	}
+
+	switch {
+	case o.valuesString != "":
+		encoded, err := json.Marshal(o.valuesString)
+		if err != nil {
+			return nil, err
+		}
+		raw.Values = encoded
+	case o.Values != nil:
+		encoded, err := json.Marshal(o.Values)
+		if err != nil {
+			return nil, err
+		}
+		raw.Values = encoded
+	}
+
+	return json.Marshal(raw)
+}
+
+// ValuesString returns the raw scalar form of optionalValues[].values (a repl template) when values
+// was provided as a string rather than a map; it returns "" for the map form.
+func (o *OptionalValue) ValuesString() string {
+	return o.valuesString
 }
 
 // HelmChartSpec defines the desired state of HelmChartSpec

--- a/apis/kots/v1beta2/optionalvalue_stringormap_test.go
+++ b/apis/kots/v1beta2/optionalvalue_stringormap_test.go
@@ -1,0 +1,85 @@
+package v1beta2
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_OptionalValue_ValuesStringOrMap verifies that spec.optionalValues[].values decodes from
+// BOTH a YAML mapping (the form KOTS sees after template rendering) and a scalar string (a
+// `repl{{ ... }}` template the Vendor Portal sees before rendering). The scalar form must NOT
+// error, otherwise the whole HelmChart CR is dropped and the release is falsely flagged "not
+// installable with KOTS". See sc-138613 / itrs-replicated#380.
+func Test_OptionalValue_ValuesStringOrMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantString bool
+	}{
+		{
+			name:       "map form",
+			input:      `{"when":"true","recursiveMerge":true,"values":{"operator":{"enabled":true}}}`,
+			wantString: false,
+		},
+		{
+			name:       "templated repl{{ }} scalar is tolerated",
+			input:      `{"when":"true","recursiveMerge":false,"values":"repl{{ ConfigOption \"override\" | nindent 8 }}"}`,
+			wantString: true,
+		},
+		{
+			name:       "{{repl }} alt-delimiter scalar is tolerated",
+			input:      `{"when":"true","values":"{{repl ConfigOption \"override\" | nindent 8 }}"}`,
+			wantString: true,
+		},
+		{
+			name:       "non-templated scalar is tolerated, not an error",
+			input:      `{"when":"true","values":"this is not a map"}`,
+			wantString: true,
+		},
+		{
+			name:       "omitted values",
+			input:      `{"when":"false"}`,
+			wantString: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ov OptionalValue
+			require.NoError(t, json.Unmarshal([]byte(tt.input), &ov))
+
+			if tt.wantString {
+				assert.Nil(t, ov.Values, "a scalar values must leave the typed map empty (type-indeterminate)")
+				assert.NotEmpty(t, ov.valuesString, "a scalar values must be preserved as a string")
+			} else {
+				assert.Empty(t, ov.valuesString)
+			}
+
+			// A marshal/unmarshal round-trip must be idempotent: a string stays a string, a map
+			// stays a map.
+			out, err := json.Marshal(ov)
+			require.NoError(t, err)
+
+			var rt OptionalValue
+			require.NoError(t, json.Unmarshal(out, &rt))
+			assert.Equal(t, ov, rt, "OptionalValue must survive a marshal/unmarshal round-trip")
+		})
+	}
+}
+
+// Test_HelmChartSpec_ToleratesTemplatedScalarOptionalValues proves the bug fix at the spec level:
+// a HelmChartSpec whose optionalValues[].values is a templated scalar must decode without error so
+// the CR is not dropped from the installability check.
+func Test_HelmChartSpec_ToleratesTemplatedScalarOptionalValues(t *testing.T) {
+	spec := `{"chart":{"name":"issue380","chartVersion":"1.0.0"},"optionalValues":[{"when":"true","recursiveMerge":true,"values":"repl{{ ConfigOption \"override\" | nindent 8 }}"}]}`
+
+	var s HelmChartSpec
+	require.NoError(t, json.Unmarshal([]byte(spec), &s))
+
+	assert.Equal(t, "issue380", s.Chart.Name)
+	require.Len(t, s.OptionalValues, 1)
+	assert.Nil(t, s.OptionalValues[0].Values, "templated scalar leaves the typed map empty")
+}

--- a/apis/kots/v1beta2/optionalvalue_stringormap_test.go
+++ b/apis/kots/v1beta2/optionalvalue_stringormap_test.go
@@ -83,3 +83,26 @@ func Test_HelmChartSpec_ToleratesTemplatedScalarOptionalValues(t *testing.T) {
 	require.Len(t, s.OptionalValues, 1)
 	assert.Nil(t, s.OptionalValues[0].Values, "templated scalar leaves the typed map empty")
 }
+
+// Test_OptionalValue_DeepCopyPreservesValuesString locks the invariant that a scalar values
+// survives DeepCopy/DeepCopyInto. Correctness holds today only because valuesString is a value-type
+// string copied by the generated `*out = *in`; this test fails loudly if that ever stops being true
+// (e.g. the field becomes a pointer/slice and the generated deepcopy stops covering it).
+func Test_OptionalValue_DeepCopyPreservesValuesString(t *testing.T) {
+	var ov OptionalValue
+	require.NoError(t, json.Unmarshal([]byte(`{"when":"true","values":"repl{{ ConfigOption \"override\" | nindent 8 }}"}`), &ov))
+	require.NotEmpty(t, ov.ValuesString())
+
+	cp := ov.DeepCopy()
+	assert.Equal(t, ov.ValuesString(), cp.ValuesString(), "scalar must survive DeepCopy")
+
+	var into OptionalValue
+	ov.DeepCopyInto(&into)
+	assert.Equal(t, ov.ValuesString(), into.ValuesString(), "scalar must survive DeepCopyInto")
+
+	orig, err := json.Marshal(ov)
+	require.NoError(t, err)
+	copied, err := json.Marshal(cp)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(orig), string(copied), "a deep copy must re-marshal identically")
+}

--- a/apis/kots/v1beta2/optionalvalue_yaml_test.go
+++ b/apis/kots/v1beta2/optionalvalue_yaml_test.go
@@ -1,0 +1,120 @@
+package v1beta2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	v1beta2 "github.com/replicatedhq/kotskinds/apis/kots/v1beta2"
+	kotsscheme "github.com/replicatedhq/kotskinds/client/kotsclientset/scheme"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+// Test_OptionalValue_YAMLDecode_StringOrMap proves the string-or-map tolerance on
+// optionalValues[].values works for YAML input, not just JSON — and that YAML and JSON decode to
+// the same thing.
+//
+// There is deliberately NO UnmarshalYAML on OptionalValue. Every real decode path converts YAML to
+// JSON and then calls json.Unmarshal: sigs.k8s.io/yaml does it directly, and the k8s
+// UniversalDeserializer (the path kots and vandoor actually use) routes YAML through its JSON/YAML
+// serializer. So the custom UnmarshalJSON fires either way. This matches the repo's existing
+// dual-type convention (multitype.BoolOrString, MappedChartValue implement JSON hooks only). Adding
+// UnmarshalYAML would be redundant. See sc-138613 / itrs-replicated#380.
+//
+// This is an external test package (v1beta2_test) on purpose: it decodes via
+// client/kotsclientset/scheme, which imports this API package, so an in-package test would be an
+// import cycle. It only needs the exported ValuesString()/Values, so external is fine.
+func Test_OptionalValue_YAMLDecode_StringOrMap(t *testing.T) {
+	tests := []struct {
+		name       string
+		yamlDoc    string
+		jsonDoc    string
+		wantString bool
+	}{
+		{
+			name: "templated repl{{ }} scalar",
+			yamlDoc: `apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: issue380
+spec:
+  chart:
+    name: issue380
+    chartVersion: 1.0.0
+  optionalValues:
+    - when: "true"
+      values: 'repl{{ ConfigOption "override" | nindent 8 }}'`,
+			jsonDoc:    `{"apiVersion":"kots.io/v1beta2","kind":"HelmChart","metadata":{"name":"issue380"},"spec":{"chart":{"name":"issue380","chartVersion":"1.0.0"},"optionalValues":[{"when":"true","values":"repl{{ ConfigOption \"override\" | nindent 8 }}"}]}}`,
+			wantString: true,
+		},
+		{
+			name: "{{repl }} alt-delimiter scalar",
+			yamlDoc: `apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: issue380
+spec:
+  chart:
+    name: issue380
+    chartVersion: 1.0.0
+  optionalValues:
+    - when: "true"
+      values: '{{repl ConfigOption "override" | nindent 8 }}'`,
+			jsonDoc:    `{"apiVersion":"kots.io/v1beta2","kind":"HelmChart","metadata":{"name":"issue380"},"spec":{"chart":{"name":"issue380","chartVersion":"1.0.0"},"optionalValues":[{"when":"true","values":"{{repl ConfigOption \"override\" | nindent 8 }}"}]}}`,
+			wantString: true,
+		},
+		{
+			name: "map values",
+			yamlDoc: `apiVersion: kots.io/v1beta2
+kind: HelmChart
+metadata:
+  name: issue380
+spec:
+  chart:
+    name: issue380
+    chartVersion: 1.0.0
+  optionalValues:
+    - when: "true"
+      values:
+        operator:
+          enabled: true`,
+			jsonDoc:    `{"apiVersion":"kots.io/v1beta2","kind":"HelmChart","metadata":{"name":"issue380"},"spec":{"chart":{"name":"issue380","chartVersion":"1.0.0"},"optionalValues":[{"when":"true","values":{"operator":{"enabled":true}}}]}}`,
+			wantString: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 1. sigs.k8s.io/yaml: YAML -> JSON -> json.Unmarshal (fires UnmarshalJSON).
+			var viaYAML v1beta2.HelmChart
+			require.NoError(t, yaml.Unmarshal([]byte(tt.yamlDoc), &viaYAML))
+
+			// 2. The k8s UniversalDeserializer — how kots/vandoor actually decode manifests.
+			obj, _, err := kotsscheme.Codecs.UniversalDeserializer().Decode([]byte(tt.yamlDoc), nil, nil)
+			require.NoError(t, err)
+			viaScheme, ok := obj.(*v1beta2.HelmChart)
+			require.True(t, ok, "decoded object must be a *v1beta2.HelmChart")
+
+			// 3. Direct JSON decode, for the equivalence assertion.
+			var viaJSON v1beta2.HelmChart
+			require.NoError(t, json.Unmarshal([]byte(tt.jsonDoc), &viaJSON))
+
+			for _, hc := range []*v1beta2.HelmChart{&viaYAML, viaScheme, &viaJSON} {
+				require.Len(t, hc.Spec.OptionalValues, 1)
+				ov := hc.Spec.OptionalValues[0]
+				if tt.wantString {
+					assert.Nil(t, ov.Values, "a scalar values must leave the typed map empty")
+					assert.NotEmpty(t, ov.ValuesString(), "a scalar values must be preserved as a string")
+				} else {
+					assert.NotNil(t, ov.Values, "a map values must populate the typed map")
+					assert.Empty(t, ov.ValuesString())
+				}
+			}
+
+			// YAML (both routes) must decode equivalently to JSON.
+			assert.Equal(t, viaJSON.Spec.OptionalValues, viaYAML.Spec.OptionalValues, "sigs.k8s.io/yaml decode must match JSON decode")
+			assert.Equal(t, viaJSON.Spec.OptionalValues, viaScheme.Spec.OptionalValues, "UniversalDeserializer decode must match JSON decode")
+		})
+	}
+}

--- a/config/crds/kots.io_helmcharts.yaml
+++ b/config/crds/kots.io_helmcharts.yaml
@@ -71,6 +71,9 @@ spec:
                       type: boolean
                     values:
                       additionalProperties: {}
+                      description: |-
+                        Values holds the map form of the optional values. This is the form KOTS decodes at install
+                        time, because templates are rendered before the manifest is unmarshalled.
                       type: object
                     when:
                       type: string
@@ -155,6 +158,9 @@ spec:
                       type: boolean
                     values:
                       additionalProperties: {}
+                      description: |-
+                        Values holds the map form of the optional values. This is the form KOTS decodes at install
+                        time, because templates are rendered before the manifest is unmarshalled.
                       type: object
                     when:
                       type: string

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apimachinery v0.34.2
 	k8s.io/client-go v0.34.2
 	sigs.k8s.io/controller-runtime v0.22.4
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -64,5 +65,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/schemas/helmchart-kots-v1beta1.json
+++ b/schemas/helmchart-kots-v1beta1.json
@@ -70,6 +70,7 @@
                 "type": "boolean"
               },
               "values": {
+                "description": "Values holds the map form of the optional values. This is the form KOTS decodes at install\ntime, because templates are rendered before the manifest is unmarshalled.",
                 "type": "object",
                 "additionalProperties": {}
               },

--- a/schemas/helmchart-kots-v1beta2.json
+++ b/schemas/helmchart-kots-v1beta2.json
@@ -70,6 +70,7 @@
                 "type": "boolean"
               },
               "values": {
+                "description": "Values holds the map form of the optional values. This is the form KOTS decodes at install\ntime, because templates are rendered before the manifest is unmarshalled.",
                 "type": "object",
                 "additionalProperties": {}
               },


### PR DESCRIPTION
## What

`spec.optionalValues[].values` on a HelmChart can legitimately be a scalar template, like:

```yaml
optionalValues:
  - when: 'repl{{ ConfigOptionEquals "override_enabled" "1" }}'
    values: 'repl{{ ConfigOption "override" | nindent 8 }}'
```

That renders to a YAML map at install time, so KOTS installs it fine. But the field was typed `map[string]MappedChartValue`, and a scalar-where-a-map-is-expected fails the typed decode. KOTS never hits this because it renders templates before unmarshalling, so it always sees a map. The Vendor Portal validates specs *before* render, so it sees the raw scalar, the decode fails, and the whole HelmChart CR gets dropped. Downstream that shows up as a false red "not installable with KOTS" badge even though the release installs cleanly. See itrs-replicated#380.

## The change

Give `OptionalValue` a custom `UnmarshalJSON`/`MarshalJSON` (v1beta1 and v1beta2) that accepts both a map and a scalar string.

- Map form decodes exactly as it did before. I deliberately kept the `Values` field type as `map[string]MappedChartValue`, so every existing accessor and every consumer that ranges or merges `optionalValue.Values` keeps compiling and behaving identically. This matters, `kots` reads it as a map in `MergeHelmChartValues` and a plain range, and I didn't want to break that.
- A scalar is preserved in an unexported `valuesString` field and leaves `Values` nil (type-indeterminate), so the CR still decodes and stays recognized. Round-trips losslessly.

This mirrors the dual-type pattern already in the repo (`multitype.BoolOrString`, `MappedChartValue`), which hook the same JSON decode path the k8s `UniversalDeserializer` uses, so the tolerance kicks in wherever specs get loaded.

## Tests

New `Test_OptionalValue_ValuesStringOrMap` in both API versions covers map form, `repl{{ }}` and `{{repl }}` templated scalars, a genuinely non-templated scalar (tolerated, not an error), omitted values, and a marshal round-trip. `Test_HelmChartSpec_ToleratesTemplatedScalarOptionalValues` proves the spec-level fix: the CR no longer drops.

`make generate` is clean (only diff is the new field doc landing in the CRD). `go test ./...`, `go vet ./...`, and `gofmt` all green.